### PR TITLE
patch for new jei version?

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ geckolib=4.2.2
 parch_mapping=2023.06.26
 
 rei_version=12.0.652
-jei_version=15.2.0.27
+jei_version=15.12.3.54
 architectury_version=9.0.7
 cloth_config_version=11.0.99
 polymorph_file_id=4928442

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Sets default memory used for gradle commands. Can be overridden by user or command line properties.
 # This is required to provide enough memory for the Minecraft decompilation process.
 org.gradle.jvmargs=-Xmx3G
-mod_version=1.2.1
+mod_version=1.2.2
 modid=craftingstation
 mc_version=1.20.1
 forge_version=47.1.3

--- a/src/main/java/tfar/craftingstation/jei/TransferHandler.java
+++ b/src/main/java/tfar/craftingstation/jei/TransferHandler.java
@@ -6,7 +6,6 @@ import mezz.jei.api.recipe.transfer.IRecipeTransferInfo;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.inventory.MenuType;
 import net.minecraft.world.inventory.Slot;
-import org.jetbrains.annotations.Nullable;
 import tfar.craftingstation.CraftingStation;
 import tfar.craftingstation.CraftingStationMenu;
 
@@ -53,7 +52,9 @@ public class TransferHandler implements IRecipeTransferInfo {
             List<Slot> slots = new ArrayList<>();
             for (int i = 10; i < 10 + menu.subContainerSize + 36; i++) {
                 Slot slot = container.getSlot(i);
-                slots.add(slot);
+                if (slot.hasItem()) {
+                    slots.add(slot);
+                }
             }
             return slots;
         } else {


### PR DESCRIPTION
sorry, kind of new to modding

i found that the bigslot class returns false to being modifiable due to not having a valid item which causes an issue with the newer jei versions

i thought it made sense to just add a check to see if a slot has an item before transferring...

please overlook this as mentioned, im pretty new to this
